### PR TITLE
ESLint config for Astro + TypeScript + React

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,99 @@
+import globals from "globals";
+import js from "@eslint/js";
+import astroPlugin from "eslint-plugin-astro";
+import jsxA11y from "eslint-plugin-jsx-a11y";
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+
+const PARSERS = { ts: tsParser, astro: astroParser };
+const PLUGINS = {
+  astro: astroPlugin,
+  ts: tseslint,
+  jsxA11y,
+  prettier: prettierPlugin,
+};
+
+// Rules
+const COMMON_RULES = { "no-mixed-spaces-and-tabs": ["error"] };
+
+const TS_RULES = {
+  ...tseslint.configs.recommended.rules,
+  "@typescript-eslint/no-unused-vars": [
+    "error",
+    { argsIgnorePattern: "^_", destructuredArrayIgnorePattern: "^_" },
+  ],
+  "@typescript-eslint/no-non-null-assertion": "off",
+};
+
+const JSX_A11Y_RULES = jsxA11y.configs.strict.rules;
+
+export default [
+  // Ignore generated folders/files
+  {
+    ignores: ["dist/**", "node_modules/**", "**/*.d.ts"],
+  },
+
+  // General Js
+  js.configs.recommended,
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      globals: { ...globals.node, ...globals.browser },
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
+    rules: COMMON_RULES,
+  },
+
+  // Typescript
+  {
+    files: ["**/*.ts"],
+    plugins: { ts: PLUGINS.ts },
+    languageOptions: {
+      parser: PARSERS.ts,
+      parserOptions: { project: "./tsconfig.json" }, // Type-aware linting
+    },
+    rules: TS_RULES,
+  },
+
+  // TSX (TypeScript + JSX)
+  {
+    files: ["**/*.tsx"],
+    plugins: { ts: PLUGINS.ts, "jsx-a11y": PLUGINS.jsxA11y },
+    languageOptions: {
+      parser: PARSERS.ts,
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+        project: "./tsconfig.json",
+      },
+    },
+    rules: { ...TS_RULES, ...JSX_A11Y_RULES },
+  },
+
+  // JSX (React)
+  {
+    files: ["**/*.jsx"],
+    plugins: { "jsx-a11y": PLUGINS.jsxA11y },
+    languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    rules: JSX_A11Y_RULES,
+  },
+
+  // Astro
+  {
+    files: ["**/*.astro"],
+    plugins: { astro: PLUGINS.astro },
+    languageOptions: {
+      parser: PARSERS.astro,
+      parserOptions: {
+        parser: PARSERS.ts,
+        extraFileExtensions: [".astro"],
+        project: "./tsconfig.json",
+      },
+    },
+    rules: {
+      ...PLUGINS.astro.configs.recommended.rules,
+      ...JSX_A11Y_RULES,
+      ...COMMON_RULES,
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -12,5 +12,14 @@
     "@tailwindcss/vite": "^4.1.11",
     "astro": "^5.12.9",
     "tailwindcss": "^4.1.11"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.35.0",
+    "@typescript-eslint/parser": "^8.44.0",
+    "astro-eslint-parser": "^1.2.2",
+    "eslint": "^9.35.0",
+    "eslint-plugin-astro": "^1.3.1",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
+    "globals": "^16.4.0"
   }
 }


### PR DESCRIPTION
### What it does

- Adds a Flat Config ESLint setup for the project.
- Supports:
  - JavaScript (`.js`)
  - TypeScript (`.ts`)
  - TSX (`.tsx`)
  - JSX (`.jsx`)
  - Astro (`.astro`)
- Integrates:
  - TypeScript linting (`@typescript-eslint`)
  - JSX accessibility rules (`eslint-plugin-jsx-a11y`)
  - Astro-specific rules (`eslint-plugin-astro`)
- Includes common rules and ignores (`dist/`, `node_modules/`, `.d.ts` files)

### Why

- Standardizes code style across Astro, React, and TypeScript files.
- Prepares the project for CI/CD linting and pre-commit hooks.
- Enables maintainable and scalable linting for future features.